### PR TITLE
convert to compile on gcc 4.4.x

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_PREREQ([2.69])
+AC_PREREQ([2.63])
 AC_INIT([pystack], [1.0], [evan@eklitzke.org])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([src/config.h])
@@ -12,14 +12,13 @@ AC_PROG_CXX
 AC_PROG_CC
 AC_PROG_INSTALL
 
-AX_CXX_COMPILE_STDCXX_11
+#AX_CXX_COMPILE_STDCXX_11
 
 # Checks for libraries.
 
 # Checks for header files.
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_HEADER_STDBOOL
 
 # Checks for library functions.
 

--- a/src/aslr.cc
+++ b/src/aslr.cc
@@ -40,7 +40,7 @@ size_t LocateLibPython(pid_t pid, const std::string &hint, std::string *path) {
       if (pos == std::string::npos) {
         throw FatalException("Did not find libpython virtual memory address");
       }
-      return std::strtol(line.substr(0, pos).c_str(), nullptr, 16);
+      return std::strtol(line.substr(0, pos).c_str(), NULL, 16);
     }
   }
   return 0;

--- a/src/ptrace.cc
+++ b/src/ptrace.cc
@@ -32,7 +32,7 @@ void PtraceAttach(pid_t pid) {
     ss << "Failed to attach to PID " << pid << ": " << strerror(errno);
     throw FatalException(ss.str());
   }
-  if (wait(nullptr) == -1) {
+  if (wait(NULL) == -1) {
     std::ostringstream ss;
     ss << "Failed to wait on PID " << pid << ": " << strerror(errno);
     throw FatalException(ss.str());

--- a/src/pyframe.cc
+++ b/src/pyframe.cc
@@ -148,9 +148,10 @@ unsigned long ThreadStateAddr(pid_t pid) {
   // the full soname. That determines where we need to look to find our symbol
   // table.
   std::string libpython;
-  for (const auto &lib : target.NeededLibs()) {
-    if (lib.find("libpython") != std::string::npos) {
-      libpython = lib;
+  auto libs = target.NeededLibs();
+  for (auto lib_i = libs.begin(); lib_i != libs.end() ; lib_i++) {
+    if ((*lib_i).find("libpython") != std::string::npos) {
+      libpython = *lib_i;
       break;
     }
   }

--- a/src/pyframe.h
+++ b/src/pyframe.h
@@ -33,8 +33,8 @@ class Frame {
   inline size_t line() const { return line_; }
 
  private:
-  const std::string file_;
-  const size_t line_;
+  std::string file_;
+  size_t line_;
 };
 
 std::ostream &operator<<(std::ostream &os, const Frame &frame);

--- a/src/pystack.cc
+++ b/src/pystack.cc
@@ -14,6 +14,8 @@
 // along with Pystack.  If not, see <http://www.gnu.org/licenses/>.
 
 #include <getopt.h>
+#include <sys/select.h>
+#include <sys/time.h>
 
 #include <chrono>
 #include <iostream>
@@ -86,7 +88,7 @@ int main(int argc, char **argv) {
     std::cerr << usage_str;
     return 1;
   }
-  long pid = std::strtol(argv[argc - 1], nullptr, 10);
+  long pid = std::strtol(argv[argc - 1], NULL, 10);
   if (pid > std::numeric_limits<pid_t>::max() ||
       pid < std::numeric_limits<pid_t>::min()) {
     std::cerr << "PID " << pid << " is out of valid PID range.\n";
@@ -113,7 +115,10 @@ int main(int argc, char **argv) {
           break;
         }
         PtraceDetach(pid);
-        std::this_thread::sleep_for(interval);
+        struct timespec timeout;
+        timeout.tv_nsec = std::chrono::duration_cast<std::chrono::nanoseconds>(interval).count();
+        pselect(0, NULL, NULL, NULL, &timeout, NULL);
+        //std::this_thread::sleep_for(interval);
         std::cout << "\n";
         PtraceAttach(pid);
       }

--- a/src/symbol.cc
+++ b/src/symbol.cc
@@ -27,9 +27,9 @@
 
 namespace pystack {
 void ELF::Close() {
-  if (addr_ != nullptr) {
+  if (addr_ != NULL) {
     munmap(addr_, length_);
-    addr_ = nullptr;
+    addr_ = NULL;
   }
 }
 
@@ -43,7 +43,7 @@ void ELF::Open(const std::string &target) {
     throw FatalException(ss.str());
   }
   length_ = lseek(fd, 0, SEEK_END);
-  addr_ = mmap(nullptr, length_, PROT_READ, MAP_SHARED, fd, 0);
+  addr_ = mmap(NULL, length_, PROT_READ, MAP_SHARED, fd, 0);
   while (close(fd) == -1) {
     ;
   }

--- a/src/symbol.h
+++ b/src/symbol.h
@@ -35,7 +35,7 @@ namespace pystack {
 // should use.
 class ELF {
  public:
-  ELF() : addr_(nullptr), length_(0), dynamic_(-1), dynstr_(-1), dynsym_(-1) {}
+  ELF() : addr_(NULL), length_(0), dynamic_(-1), dynstr_(-1), dynsym_(-1) {}
   ~ELF() { Close(); }
 
   // Open a file


### PR DESCRIPTION
This now compiles on GCC 4.4.7, although it only prints out "No active frame for the Python interpreter." when run, so it's still somehow broken.

The time stuff is gross; I didn't really spend enough time reading the `std::chrono::duration` docs to figure out how to get a real `struct timespec` out, although I'm sure there's a way.